### PR TITLE
Adding the option to provide client certificates if necessary

### DIFF
--- a/ldap-client.go
+++ b/ldap-client.go
@@ -24,6 +24,7 @@ type LDAPClient struct {
 	InsecureSkipVerify bool
 	UseSSL             bool
 	SkipTLS            bool
+	ClientCertificates []tls.Certificate // Adding client certificates
 }
 
 // Connect connects to the ldap backend.
@@ -46,10 +47,14 @@ func (lc *LDAPClient) Connect() error {
 				}
 			}
 		} else {
-			l, err = ldap.DialTLS("tcp", address, &tls.Config{
+			config := &tls.Config{
 				InsecureSkipVerify: lc.InsecureSkipVerify,
 				ServerName:         lc.ServerName,
-			})
+			}
+			if lc.ClientCertificates != nil && len(lc.ClientCertificates) > 0 {
+				config.Certificates = lc.ClientCertificates
+			}
+			l, err = ldap.DialTLS("tcp", address, config)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
As this library is encapsulating the LDAP library options, it is good to provide an option to users that need to provider client side certificates if necessary