### PR TITLE
Support to get DN of user

### DIFF
--- a/ldap-client.go
+++ b/ldap-client.go
@@ -114,7 +114,11 @@ func (lc *LDAPClient) Authenticate(username, password string) (bool, map[string]
 	userDN := sr.Entries[0].DN
 	user := map[string]string{}
 	for _, attr := range lc.Attributes {
-		user[attr] = sr.Entries[0].GetAttributeValue(attr)
+		if attr == "dn" {
+			user["dn"] = sr.Entries[0].DN
+		} else {
+			user[attr] = sr.Entries[0].GetAttributeValue(attr)
+		}
 	}
 
 	// Bind as the user to verify their password


### PR DESCRIPTION
I want to use DN of user. 

However, there was no way to get the DN.
Therefore, if `"dn"` is included in the attribute, we correctly added DN as an attribute.