### PR TITLE
Bind before getting groups of user

### DIFF
--- a/ldap-client.go
+++ b/ldap-client.go
@@ -141,6 +141,14 @@ func (lc *LDAPClient) GetGroupsOfUser(username string) ([]string, error) {
 		return nil, err
 	}
 
+	// First bind with a read only user
+	if lc.BindDN != "" && lc.BindPassword != "" {
+		err = lc.Conn.Bind(lc.BindDN, lc.BindPassword)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	searchRequest := ldap.NewSearchRequest(
 		lc.Base,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,


### PR DESCRIPTION
In some cases, we will not want to authenticate a user, only get their groups, such as when performing access control for a user authenticated elsewhere.  In such a case, we will not have bound the connection to the LDAP server using the read-only user, so if the LDAP server does not allow unauthenticated access, our GetGroupsOfUser call will fail.

Ensure we bind using the read-only user, if one is provided, before trying to fetch the user's groups.
